### PR TITLE
Implement run tracking with stable finding IDs

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, List
 import json
+import logging
 
 
 # ----- Stubs -----------------------------------------------------------------
@@ -46,6 +47,7 @@ class Orchestrator:
 
     def __init__(self, agent: Callable[[str], str]):
         self.agent = agent
+        self.logger = logging.getLogger(__name__)
 
     # -- Seed input -----------------------------------------------------------
     def load_manifest(self, manifest_path: Path) -> List[Path]:
@@ -80,7 +82,8 @@ class Orchestrator:
         return None
 
     def process_findings(self, findings_dir: Path) -> None:
-        for finding_file in findings_dir.glob("*.json"):
+        for finding_file in findings_dir.glob("finding_*.json"):
+            self.logger.info("Processing %s", finding_file.name)
             with open(finding_file) as fh:
                 finding = json.load(fh)
             conditions = self.derive_conditions(finding)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,29 +1,125 @@
 """Run the prototype orchestration pipeline."""
+from __future__ import annotations
+
 from pathlib import Path
+import hashlib
 import json
+import logging
+import time
 
 from agent import run_agent
 from orchestrator import Orchestrator
-
+from util.git import get_git_short, is_dirty
+from util.time import utc_now_iso, utc_timestamp
+from util.paths import repo_rel, REPO_ROOT
+from util.io import atomic_write
 
 PROMPT_PREFIX = "Analyze file: "
+VERSION = "0.1"
+
+
+def validate_manifest(manifest_path: Path) -> list[Path]:
+    """Validate manifest file paths and return normalized repo-relative Paths."""
+    paths: list[Path] = []
+    seen: set[str] = set()
+    with open(manifest_path) as fh:
+        for line in fh:
+            entry = line.strip()
+            if not entry:
+                continue
+            rel = repo_rel(Path(entry))
+            abs_path = REPO_ROOT / rel
+            if not abs_path.exists():
+                raise FileNotFoundError(f"Missing manifest file: {entry}")
+            rel_str = rel.as_posix()
+            if rel_str in seen:
+                raise ValueError(f"Duplicate path in manifest: {entry}")
+            seen.add(rel_str)
+            paths.append(rel)
+    return sorted(paths, key=lambda p: p.as_posix())
+
+
+def write_run_json(run_path: Path, data: dict) -> None:
+    atomic_write(run_path / "run.json", json.dumps(data, indent=2).encode())
 
 
 def main() -> None:
     manifest_path = Path("manifest.txt")
-    findings_dir = Path("findings")
-    findings_dir.mkdir(exist_ok=True)
+    try:
+        manifest_files = validate_manifest(manifest_path)
+    except Exception as exc:
+        print(f"Manifest error: {exc}")
+        raise SystemExit(1)
+
+    git_short = get_git_short()
+    run_ts = utc_timestamp()
+    run_id = f"{run_ts}_{git_short}"
+    findings_root = Path("findings")
+    run_path = findings_root / f"run_{run_id}"
+    while run_path.exists():
+        time.sleep(1)
+        run_ts = utc_timestamp()
+        run_id = f"{run_ts}_{git_short}"
+        run_path = findings_root / f"run_{run_id}"
+    run_path.mkdir(parents=True, exist_ok=False)
+
+    logger = logging.getLogger("orchestrator")
+    logger.setLevel(logging.INFO)
+    fh = logging.FileHandler(run_path / "orchestrator.log")
+    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(fh)
+
+    run_data = {
+        "run_id": run_id,
+        "manifest_path": str(manifest_path),
+        "prompt_prefix": PROMPT_PREFIX,
+        "started_at": utc_now_iso(),
+        "finished_at": None,
+        "counts": {"manifest_files": 0, "findings_written": 0, "errors": 0},
+        "git": {"commit": git_short, "dirty": is_dirty()},
+        "version": VERSION,
+    }
+    write_run_json(run_path, run_data)
+
+    counts = run_data["counts"]
+    counts["manifest_files"] = len(manifest_files)
 
     orch = Orchestrator(run_agent)
-    findings = orch.gather_initial_findings(manifest_path, PROMPT_PREFIX)
 
-    # Persist initial findings
-    for idx, finding in enumerate(findings, 1):
-        with open(findings_dir / f"finding_{idx}.json", "w") as fh:
-            json.dump(finding, fh, indent=2)
+    for rel_path in manifest_files:
+        try:
+            abs_path = REPO_ROOT / rel_path
+            file_bytes = abs_path.read_bytes()
+            finding_id = hashlib.sha1(rel_path.as_posix().encode()).hexdigest()[:12]
+            finding = {
+                "finding_id": finding_id,
+                "claim": "",
+                "files": [rel_path.as_posix()],
+                "evidence": {},
+                "provenance": {
+                    "run_id": run_id,
+                    "created_at": utc_now_iso(),
+                    "input_hash": hashlib.sha1(file_bytes).hexdigest(),
+                    "file_size": len(file_bytes),
+                    "path": rel_path.as_posix(),
+                },
+                "status": "seeded",
+                "conditions": [],
+            }
+            atomic_write(
+                run_path / f"finding_{finding_id}.json",
+                json.dumps(finding, indent=2).encode(),
+            )
+            counts["findings_written"] += 1
+            logger.info("Seeded finding %s", finding_id)
+        except Exception as exc:  # per-file errors
+            logger.error("Error processing %s: %s", rel_path, exc)
+            counts["errors"] += 1
 
-    # Process each finding
-    orch.process_findings(findings_dir)
+    orch.process_findings(run_path)
+
+    run_data["finished_at"] = utc_now_iso()
+    write_run_json(run_path, run_data)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,122 @@
+import json
+import sys
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# ensure repo root on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from util.io import atomic_write
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    findings = Path("findings")
+    if findings.exists():
+        shutil.rmtree(findings)
+    findings.mkdir()
+    manifest = Path("manifest.txt")
+    original = manifest.read_text()
+    yield
+    manifest.write_text(original)
+    if findings.exists():
+        shutil.rmtree(findings)
+
+
+def run_pipeline() -> subprocess.CompletedProcess:
+    return subprocess.run([
+        "python",
+        "run_pipeline.py",
+    ], capture_output=True, text=True)
+
+
+def get_run_dirs():
+    return sorted(Path("findings").glob("run_*/"))
+
+
+def read_run_json(run_dir: Path) -> dict:
+    return json.loads((run_dir / "run.json").read_text())
+
+
+def test_stable_ids_and_run_separation():
+    manifest = Path("manifest.txt")
+    manifest.write_text("\n".join([
+        "examples/example1.py",
+        "examples/example2.py",
+    ]))
+    res1 = run_pipeline()
+    assert res1.returncode == 0
+    dirs_after_first = get_run_dirs()
+    assert len(dirs_after_first) == 1
+    first_dir = dirs_after_first[0]
+    files_first = {p.name for p in first_dir.glob("finding_*.json")}
+
+    manifest.write_text("\n".join([
+        "examples/example2.py",
+        "examples/example1.py",
+    ]))
+    res2 = run_pipeline()
+    assert res2.returncode == 0
+    dirs_after_second = get_run_dirs()
+    assert len(dirs_after_second) == 2
+    second_dir = sorted(dirs_after_second)[-1]
+    files_second = {p.name for p in second_dir.glob("finding_*.json")}
+
+    assert files_first == files_second
+
+
+def test_invalid_manifest_errors():
+    manifest = Path("manifest.txt")
+    # duplicate and missing
+    manifest.write_text("\n".join([
+        "examples/example1.py",
+        "examples/example1.py",
+    ]))
+    res = run_pipeline()
+    assert res.returncode != 0
+    assert get_run_dirs() == []
+
+    # out-of-repo
+    manifest.write_text("../examples/example1.py")
+    res = run_pipeline()
+    assert res.returncode != 0
+    assert get_run_dirs() == []
+
+    # missing file
+    manifest.write_text("examples/missing.py")
+    res = run_pipeline()
+    assert res.returncode != 0
+    assert get_run_dirs() == []
+
+
+def test_run_json_timestamps_counts():
+    manifest = Path("manifest.txt")
+    manifest.write_text("\n".join([
+        "examples/example1.py",
+        "examples/example2.py",
+    ]))
+    res = run_pipeline()
+    assert res.returncode == 0
+    run_dir = get_run_dirs()[0]
+    run_data = read_run_json(run_dir)
+    assert run_data["finished_at"] is not None
+    assert run_data["counts"]["manifest_files"] == 2
+    assert run_data["counts"]["findings_written"] == 2
+    assert run_data["counts"]["errors"] == 0
+
+
+def test_atomic_write_no_partial_on_error(tmp_path, monkeypatch):
+    target = tmp_path / "out.txt"
+
+    def boom(src, dst):
+        raise OSError("fail")
+
+    monkeypatch.setattr(os, "replace", boom)
+    with pytest.raises(OSError):
+        atomic_write(target, b"data")
+    assert not target.exists()
+    assert not any(tmp_path.iterdir())

--- a/util/git.py
+++ b/util/git.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def get_git_short() -> str:
+    """Return the short hash of HEAD or 'no_git' if unavailable."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        return out
+    except Exception:
+        return "no_git"
+
+
+def is_dirty() -> bool:
+    """Return True if the git working tree has uncommitted changes."""
+    try:
+        out = subprocess.check_output(
+            ["git", "status", "--porcelain"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        return bool(out.strip())
+    except Exception:
+        return False

--- a/util/io.py
+++ b/util/io.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    """Write bytes to path atomically."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+        os.replace(tmp_path, path)
+    except Exception:
+        os.unlink(tmp_path)
+        raise

--- a/util/paths.py
+++ b/util/paths.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def repo_rel(path: Path) -> Path:
+    """Return a repository-relative, normalized path.
+
+    Raises ValueError if the path is outside the repository.
+    """
+    path = Path(path)
+    abs_path = (REPO_ROOT / path).resolve() if not path.is_absolute() else path.resolve()
+    try:
+        rel = abs_path.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"{path} is outside the repository") from exc
+    return rel

--- a/util/time.py
+++ b/util/time.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utc_now_iso() -> str:
+    """Return current UTC time in ISO 8601 format with second precision."""
+    return datetime.utcnow().replace(microsecond=0, tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def utc_timestamp() -> str:
+    """Return current UTC time formatted as YYYYMMDD_HHMMSS."""
+    return datetime.utcnow().strftime("%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Summary
- add utility helpers for git metadata, timestamps, paths and atomic writes
- track runs in unique `findings/run_<ts>_<commit>` directories with manifest validation and stable hashed finding IDs
- log orchestrator activity and restrict processing to per-run findings
- test run separation, manifest errors, timestamp/count correctness, and atomic writes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898168051408324b129663bdbf98ce8