### PR TITLE
feat: integrate OpenAI into orchestrator

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,8 +1,10 @@
 """Prototype orchestrator for processing findings.
 
 This module coordinates between a manifest, an agent, and stored findings.
-The agent and LLM completion are represented by stubs to keep the prototype
-self-contained.
+LLM calls are routed through :mod:`util.openai` so that judgment, condition
+generation, and task generation can be powered by the OpenAI API when
+available.  In environments without an API key the orchestrator gracefully
+falls back to stub behaviour.
 """
 from __future__ import annotations
 
@@ -12,12 +14,10 @@ from typing import Callable, Dict, List
 import json
 import logging
 
-
-# ----- Stubs -----------------------------------------------------------------
-
-def orchestrator_completion(prompt: str) -> str:
-    """Stub for LLM completion used by the orchestrator."""
-    return ""
+from util.openai import (
+    openai_generate_response,
+    openai_parse_function_call,
+)
 
 
 # ----- Data structures -------------------------------------------------------
@@ -71,15 +71,141 @@ class Orchestrator:
 
     # -- Orchestration per finding -------------------------------------------
     def derive_conditions(self, finding: Dict) -> List[Condition]:
-        # Deterministically derive a minimal set of conditions.
-        # Stub implementation returns no conditions.
-        orchestrator_completion(finding.get("claim", ""))
-        return []
+        """Use the LLM to deterministically derive conditions.
+
+        The model is expected to call the ``emit_conditions`` function with a
+        JSON payload of ``{"conditions": ["..."]}``.  If the OpenAI client is
+        unavailable or the call fails, an empty list is returned.
+        """
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Given a bug finding, extract minimal checkable conditions "
+                    "and respond via function call."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Finding claim: {finding.get('claim', '')}",
+            },
+        ]
+        functions = [
+            {
+                "name": "emit_conditions",
+                "description": "Return a list of condition descriptions.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "conditions": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        }
+                    },
+                    "required": ["conditions"],
+                },
+            }
+        ]
+        try:
+            response = openai_generate_response(
+                messages=messages,
+                functions=functions,
+                function_call={"name": "emit_conditions"},
+            )
+            _, data = openai_parse_function_call(response)
+            conds = [Condition(description=d) for d in data.get("conditions", [])]
+            return conds
+        except Exception as exc:  # pragma: no cover - network/credential issues
+            self.logger.warning("condition generation failed: %s", exc)
+            return []
+
+    def generate_tasks(self, condition: Condition) -> List[str]:
+        """Generate tasks to gather evidence for ``condition`` using the LLM."""
+        messages = [
+            {"role": "system", "content": "You generate step-by-step tasks."},
+            {
+                "role": "user",
+                "content": f"Condition: {condition.description}",
+            },
+        ]
+        functions = [
+            {
+                "name": "emit_tasks",
+                "description": "Return a list of tasks to gather evidence.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "tasks": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        }
+                    },
+                    "required": ["tasks"],
+                },
+            }
+        ]
+        try:
+            response = openai_generate_response(
+                messages=messages,
+                functions=functions,
+                function_call={"name": "emit_tasks"},
+            )
+            _, data = openai_parse_function_call(response)
+            return data.get("tasks", [])
+        except Exception as exc:  # pragma: no cover
+            self.logger.warning("task generation failed: %s", exc)
+            return []
+
+    def judge_condition(self, condition: Condition) -> str:
+        """Use the LLM to judge whether ``condition`` is satisfied."""
+        messages = [
+            {
+                "role": "system",
+                "content": "Decide if a condition is satisfied based on evidence.",
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Condition: {condition.description}\nEvidence: {condition.evidence}"
+                ),
+            },
+        ]
+        functions = [
+            {
+                "name": "judge_condition",
+                "description": "Judge condition state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "enum": ["satisfied", "failed", "unknown"],
+                        }
+                    },
+                    "required": ["state"],
+                },
+            }
+        ]
+        try:
+            response = openai_generate_response(
+                messages=messages,
+                functions=functions,
+                function_call={"name": "judge_condition"},
+            )
+            _, data = openai_parse_function_call(response)
+            return data.get("state", "unknown")
+        except Exception as exc:  # pragma: no cover
+            self.logger.warning("judgement failed: %s", exc)
+            return "unknown"
 
     def resolve_condition(self, condition: Condition) -> None:
-        # Stub evaluation loop. Real implementation would create tasks and
-        # interact with agents to gather evidence.
-        return None
+        """Resolve a condition by generating tasks and judging the result."""
+        tasks = self.generate_tasks(condition)
+        if not tasks:
+            return
+        # Agent execution is not implemented; log tasks for now.
+        self.logger.info("Tasks for condition '%s': %s", condition.description, tasks)
+        condition.state = self.judge_condition(condition)
 
     def process_findings(self, findings_dir: Path) -> None:
         for finding_file in findings_dir.glob("finding_*.json"):

--- a/util/openai.py
+++ b/util/openai.py
@@ -1,0 +1,88 @@
+"""Thin wrapper around the OpenAI client used by phase mode."""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+_client = None
+
+
+def openai_configure_api(api_key: Optional[str] = None):
+    """Retrieve key, build global client, log success."""
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        from openai import OpenAI
+    except Exception as exc:  # pragma: no cover - import failure path
+        logging.warning("openai package not available: %s", exc)
+        return None
+    key = api_key or os.environ.get("OPENAI_API_KEY")
+    if not key:
+        logging.warning("OPENAI_API_KEY is not set")
+        return None
+    _client = OpenAI(api_key=key)
+    logging.info("OpenAI client configured")
+    return _client
+
+
+def openai_generate_response(
+    *,
+    messages: List[Dict[str, str]],
+    functions: Optional[List[Dict[str, Any]]] = None,
+    function_call: Optional[str | Dict[str, str]] = "auto",
+    model: str = "o3",
+    reasoning_effort: str = "high",
+    service_tier: str = "flex",
+    **extra: Any,
+):
+    """Wrapper around ``client.responses.create`` with defaults."""
+    client = openai_configure_api()
+    if client is None:
+        raise RuntimeError("OpenAI client is not configured")
+
+    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
+    if functions:
+        tools.extend({"type": "function", **f} for f in functions)
+
+    params: Dict[str, Any] = {
+        "model": model,
+        "input": messages,
+        "tools": tools,
+        "reasoning": {"effort": reasoning_effort},
+        "service_tier": service_tier,
+        **extra,
+    }
+
+    logging.info("Sending:\n%s", messages)
+    response = client.responses.create(**params)
+    logging.info("Received:\n%s", response)
+    return response
+
+
+def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
+    """Extract function call data from a Responses API result."""
+    fc = None
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) in {"function_call", "tool_call"}:
+            fc = item
+            break
+    if not fc:
+        output = getattr(response, "output", None)
+        msg = output[0] if output else None
+        content = getattr(msg, "content", []) if msg else []
+        for item in content:
+            if getattr(item, "type", None) == "tool_call":
+                fc = item
+                break
+    if not fc:
+        return None, None
+    name = getattr(fc, "name", None)
+    args_str = getattr(fc, "arguments", "") or "{}"
+    try:
+        data = json.loads(args_str)
+    except json.JSONDecodeError:
+        data = {}
+    logging.info("Function call %s with %s", name, data)
+    return name, data


### PR DESCRIPTION
## Summary
- hook orchestrator into OpenAI wrapper for condition generation, task creation and judgement
- add util.openai helper for configuring client and parsing function call responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689819dd3eb8832494eeb40504e64823