### PR TITLE
Make pipeline deterministic and evidence-driven

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,11 +1,63 @@
-"""Agent stub for executing high-level tasks on a shell."""
+"""Deterministic agent for safe task execution."""
+from __future__ import annotations
+
+from pathlib import Path
+import ast
+import hashlib
 from typing import Any
+
+from util.paths import REPO_ROOT, repo_rel
+
+MAX_BYTES = 100_000
+
+
+def _safe_path(p: str) -> Path:
+    rel = repo_rel(Path(p))
+    return REPO_ROOT / rel
+
+
+def _sha1_bytes(b: bytes) -> str:
+    return hashlib.sha1(b).hexdigest()
 
 
 def run_agent(goal: str) -> Any:
-    """Stub agent API.
-
-    In production this function will execute the provided goal on a shell
-    and return structured findings.
-    """
-    return ""
+    try:
+        if goal.startswith("read:"):
+            p = _safe_path(goal.split(":", 1)[1])
+            b = p.read_bytes()[:MAX_BYTES]
+            return {
+                "type": "read",
+                "path": str(p),
+                "bytes": b.decode("utf-8", "replace"),
+                "sha1": _sha1_bytes(b),
+            }
+        if goal.startswith("stat:"):
+            p = _safe_path(goal.split(":", 1)[1])
+            b = p.read_bytes()
+            return {
+                "type": "stat",
+                "path": str(p),
+                "size": len(b),
+                "sha1": _sha1_bytes(b),
+            }
+        if goal.startswith("py:functions:"):
+            p = _safe_path(goal.split(":", 2)[2])
+            tree = ast.parse(p.read_text())
+            defs = [
+                {"name": n.name, "args": len(n.args.args)}
+                for n in ast.walk(tree)
+                if isinstance(n, ast.FunctionDef)
+            ]
+            return {"type": "py:functions", "path": str(p), "functions": defs}
+        if goal.startswith("py:classes:"):
+            p = _safe_path(goal.split(":", 2)[2])
+            tree = ast.parse(p.read_text())
+            classes = []
+            for n in ast.walk(tree):
+                if isinstance(n, ast.ClassDef):
+                    methods = [m.name for m in n.body if isinstance(m, ast.FunctionDef)]
+                    classes.append({"name": n.name, "methods": methods})
+            return {"type": "py:classes", "path": str(p), "classes": classes}
+        return {"type": "noop", "goal": goal}
+    except Exception as exc:  # pragma: no cover - best effort
+        return {"error": str(exc), "goal": goal}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from agent import run_agent
+
+
+def test_read():
+    res = run_agent("read:examples/example1.py")
+    assert res["type"] == "read"
+    assert "bytes" in res and "sha1" in res
+
+
+def test_stat():
+    res = run_agent("stat:examples/example1.py")
+    assert res["type"] == "stat"
+    assert "size" in res and "sha1" in res
+
+
+def test_py_functions():
+    res = run_agent("py:functions:examples/example1.py")
+    funcs = res.get("functions", [])
+    assert {"name": "add", "args": 2} in funcs
+
+
+def test_py_classes():
+    res = run_agent("py:classes:examples/example2.py")
+    classes = res.get("classes", [])
+    assert {"name": "Greeter", "methods": ["greet"]} in classes

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from orchestrator import Orchestrator, Condition
+
+
+def fake_agent(goal: str) -> str:
+    return ""
+
+
+def test_judge_condition_requires_evidence(monkeypatch):
+    orch = Orchestrator(fake_agent)
+
+    def boom(*args, **kwargs):  # should not be called
+        raise AssertionError("openai called")
+
+    monkeypatch.setattr("orchestrator.openai_generate_response", boom)
+    cond = Condition(description="x")
+    assert orch.judge_condition(cond) == "unknown"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import json
+import json
 import sys
 import os
 import shutil
@@ -107,6 +108,22 @@ def test_run_json_timestamps_counts():
     assert run_data["counts"]["manifest_files"] == 2
     assert run_data["counts"]["findings_written"] == 2
     assert run_data["counts"]["errors"] == 0
+
+
+def test_seeded_findings_have_claim_and_evidence():
+    manifest = Path("manifest.txt")
+    manifest.write_text("examples/example1.py")
+    res = run_pipeline()
+    assert res.returncode == 0
+    run_dir = get_run_dirs()[0]
+    finding_files = list(run_dir.glob("finding_*.json"))
+    assert finding_files
+    for fp in finding_files:
+        data = json.loads(fp.read_text())
+        assert data["claim"]
+        assert data["evidence"].get("seed") is not None
+        assert "tasks_log" in data
+        assert "conditions" in data
 
 
 def test_atomic_write_no_partial_on_error(tmp_path, monkeypatch):

--- a/util/openai.py
+++ b/util/openai.py
@@ -35,6 +35,7 @@ def openai_generate_response(
     model: str = "o3",
     reasoning_effort: str = "high",
     service_tier: str = "flex",
+    temperature: float = 0,
     **extra: Any,
 ):
     """Wrapper around ``client.responses.create`` with defaults."""
@@ -42,7 +43,7 @@ def openai_generate_response(
     if client is None:
         raise RuntimeError("OpenAI client is not configured")
 
-    tools: List[Dict[str, Any]] = [{"type": "web_search"}]
+    tools: List[Dict[str, Any]] = []
     if functions:
         tools.extend({"type": "function", **f} for f in functions)
 
@@ -52,6 +53,7 @@ def openai_generate_response(
         "tools": tools,
         "reasoning": {"effort": reasoning_effort},
         "service_tier": service_tier,
+        "temperature": temperature,
         **extra,
     }
 


### PR DESCRIPTION
## Summary
- Seed findings via orchestrator to capture initial claims, seed evidence, and task logs
- Execute deterministic read/stat/Python collectors through new agent and gate condition judgments on evidence
- Pin OpenAI temperature and add tests for agent tasks, evidence gating, and claim persistence

## Testing
- `pytest tests/test_agent.py tests/test_orchestrator.py tests/test_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68981b6ce0748324ba9082e4cd4d034a