### PR TITLE
refactor orchestration for determinism

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -126,6 +126,29 @@ def test_seeded_findings_have_claim_and_evidence():
         assert "conditions" in data
 
 
+def test_manifest_is_single_source(monkeypatch):
+    import run_pipeline as rp
+
+    manifest = Path("manifest.txt")
+    manifest.write_text("examples/example1.py")
+    called = {}
+
+    def fake_validate(path):
+        called["validate"] = True
+        return [Path("examples/example1.py")]
+
+    def fake_gather(self, files, prefix):
+        called["gather"] = files
+        return []
+
+    monkeypatch.setattr(rp, "validate_manifest", fake_validate)
+    monkeypatch.setattr("orchestrator.Orchestrator.gather_initial_findings", fake_gather)
+
+    rp.main()
+    assert called.get("validate") is True
+    assert called.get("gather") == [Path("examples/example1.py")]
+
+
 def test_atomic_write_no_partial_on_error(tmp_path, monkeypatch):
     target = tmp_path / "out.txt"
 

--- a/util/manifest.py
+++ b/util/manifest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from util.paths import repo_rel, REPO_ROOT
+
+
+def validate_manifest(manifest_path: Path) -> List[Path]:
+    """Validate manifest file paths and return normalized repo-relative Paths."""
+    paths: List[Path] = []
+    seen: set[str] = set()
+    with open(manifest_path) as fh:
+        for line in fh:
+            entry = line.strip()
+            if not entry:
+                continue
+            rel = repo_rel(Path(entry))
+            abs_path = REPO_ROOT / rel
+            if not abs_path.exists():
+                raise FileNotFoundError(f"Missing manifest file: {entry}")
+            rel_str = rel.as_posix()
+            if rel_str in seen:
+                raise ValueError(f"Duplicate path in manifest: {entry}")
+            seen.add(rel_str)
+            paths.append(rel)
+    return sorted(paths, key=lambda p: p.as_posix())


### PR DESCRIPTION
## Summary
- centralize manifest validation and wire deterministic initial findings
- add reproducible task planning, judgment shortcuts, and logging
- support optional on-disk LLM memoization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68981ff796a88324a7ba7855e00764ed