### PR TITLE
Integrate Codex-based execution into orchestration pipeline

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -7,7 +7,8 @@ import json
 import logging
 import time
 
-from agent import run_agent
+from codex_dispatch import CodexClient
+from codex_agent import CodexAgent
 from orchestrator import Orchestrator
 from util.git import get_git_short, is_dirty
 from util.time import utc_now_iso, utc_timestamp
@@ -76,7 +77,9 @@ def main() -> None:
     counts = run_data["counts"]
     counts["manifest_files"] = len(manifest_files)
 
-    orch = Orchestrator(run_agent)
+    codex = CodexClient()
+    codex_agent = CodexAgent(codex, workdir=str(REPO_ROOT))
+    orch = Orchestrator(codex_agent.run)
 
     try:
         initial = orch.gather_initial_findings(manifest_files, PROMPT_PREFIX)

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -60,6 +60,24 @@ def test_py_classes():
     assert res == data
 
 
+def test_discover():
+    data = {"type": "discover", "claim": "c", "files": ["p"], "evidence": {}}
+    agent = _agent_with_result(data)
+    res = agent.run("codex:discover:p")
+    assert res == data
+
+
+def test_exec():
+    data = {
+        "type": "exec",
+        "task": "stat:p",
+        "result": {"type": "stat", "path": "p", "size": 1, "sha1": "aa"},
+    }
+    agent = _agent_with_result(data)
+    res = agent.run("codex:exec:p::stat:p")
+    assert res == data
+
+
 def test_timeout():
     client = DummyCodexClient(error=CodexTimeout("boom"))
     workdir = str(Path(__file__).resolve().parents[1])

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -97,7 +97,9 @@ def test_execute_tasks_atomic_write_no_partial_on_error(tmp_path, monkeypatch):
     orch = Orchestrator(lambda x: "out")
     cond = Condition(description="c")
     finding = tmp_path / "f.json"
-    finding.write_text(json.dumps({"tasks_log": []}))
+    finding.write_text(
+        json.dumps({"tasks_log": [], "provenance": {"path": "examples/example1.py"}})
+    )
 
     from util import io as uio
 
@@ -110,7 +112,10 @@ def test_execute_tasks_atomic_write_no_partial_on_error(tmp_path, monkeypatch):
         orch._execute_tasks(finding, cond, [{"task": "t", "original": "t"}])
 
     # Original file untouched and valid JSON
-    assert json.loads(finding.read_text()) == {"tasks_log": []}
+    assert json.loads(finding.read_text()) == {
+        "tasks_log": [],
+        "provenance": {"path": "examples/example1.py"},
+    }
     assert list(tmp_path.iterdir()) == [finding]
 
 


### PR DESCRIPTION
## Summary
- route pipeline through CodexAgent instead of deterministic run_agent
- orchestrator seeds, plans, and executes via new `codex:discover` and `codex:exec` verbs
- allow planner to emit raw task strings without normalization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689825254518832487933aa426af6f1d