### PR TITLE
Fix Responses API mismatch in openai wrapper

### DIFF
--- a/tests/test_openai_parse.py
+++ b/tests/test_openai_parse.py
@@ -1,0 +1,76 @@
+import json
+
+from util.openai import openai_parse_function_call
+
+
+def test_parse_responses_top_level():
+    resp = {
+        "output": [
+            {
+                "type": "tool_call",
+                "name": "emit_tasks",
+                "arguments": json.dumps({"tasks": ["stat:x"]}),
+            }
+        ]
+    }
+    assert openai_parse_function_call(resp) == ("emit_tasks", {"tasks": ["stat:x"]})
+
+
+def test_parse_responses_nested_content():
+    resp = {
+        "output": [
+            {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "emit_conditions",
+                        "input": {"conditions": ["A"]},
+                    }
+                ]
+            }
+        ]
+    }
+    assert openai_parse_function_call(resp) == (
+        "emit_conditions",
+        {"conditions": ["A"]},
+    )
+
+
+def test_parse_chat_tool_calls():
+    resp = {
+        "choices": [
+            {
+                "message": {
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "emit_tasks",
+                                "arguments": json.dumps({"tasks": []}),
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    assert openai_parse_function_call(resp) == ("emit_tasks", {"tasks": []})
+
+
+def test_parse_chat_function_call():
+    resp = {
+        "choices": [
+            {
+                "message": {
+                    "function_call": {
+                        "name": "emit_conditions",
+                        "arguments": json.dumps({"conditions": ["X"]}),
+                    }
+                }
+            }
+        ]
+    }
+    assert openai_parse_function_call(resp) == (
+        "emit_conditions",
+        {"conditions": ["X"]},
+    )
+


### PR DESCRIPTION
## Summary
- Build tools list using Responses API shape and allow chat-style input
- Parse function calls from Responses or legacy Chat completions
- Add unit tests for parser across four response formats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898297e61b48324872a7816b5e376e5