### PR TITLE
Fail fast on OpenAI errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This repository demonstrates a deterministic, evidence-driven workflow for validating bug claims. The process is divided into the following stages:
 
+> **Note**: The pipeline requires a functioning OpenAI configuration. If any
+LLM call fails after internal retries, the run aborts and reports the error.
+
 1. **Seed Input**
    - Begin with a single manifest file that lists N code files.
    - For each file in the manifest, invoke an agent using a fixed, prefixed prompt template.

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -121,7 +121,14 @@ def main() -> None:
             logger.error("Error processing %s: %s", f, exc)
             counts["errors"] += 1
 
-    orch.process_findings(run_path)
+    try:
+        orch.process_findings(run_path)
+    except Exception as exc:
+        logger.error("Aborting run due to LLM failure: %s", exc)
+        counts["errors"] += 1
+        run_data["finished_at"] = utc_now_iso()
+        write_run_json(run_path, run_data)
+        raise SystemExit(1)
 
     run_data["finished_at"] = utc_now_iso()
     write_run_json(run_path, run_data)


### PR DESCRIPTION
## Summary
- remove fallback condition/task generation and bump orchestrator to 0.2
- add retry wrapper for OpenAI calls and fail-fast pipeline abort on exhaustion
- update docs and tests, including new abort test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982c396bf4832496ee81740890f58f