### PR TITLE
Add future annotations for Python 3.9 compatibility

### DIFF
--- a/util/openai.py
+++ b/util/openai.py
@@ -1,5 +1,7 @@
 """Thin wrapper around the OpenAI client used by phase mode."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os


### PR DESCRIPTION
## Summary
- ensure util/openai.py works on Python 3.9 by deferring type-hint evaluation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982e74d22c832484ef36aea703d925