### PR TITLE
Add helper for invoking codex

### DIFF
--- a/codex_exec.py
+++ b/codex_exec.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from pathlib import Path
+from typing import Sequence, Tuple
+
+
+def _invoke_codex(cmd: Sequence[str], prompt: str, timeout: float) -> Tuple[str, str]:
+    """Execute ``codex`` with ``prompt`` and return its stdout/stderr.
+
+    The command should include ``--output-last-message <path>`` so that the
+    final assistant message is persisted to disk by ``codex`` itself.  This
+    helper only handles process invocation and timeout/return-code management;
+    callers are expected to read ``output-last-message`` afterwards.
+    """
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+    )
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(prompt + "\n")
+        proc.stdin.flush()
+        proc.stdin.close()
+        proc.stdin = None
+
+        out, err = proc.communicate(timeout=timeout)
+        if proc.returncode != 0:
+            raise subprocess.CalledProcessError(proc.returncode, cmd, output=out, stderr=err)
+    except subprocess.TimeoutExpired as te:
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(proc.pid, signal.SIGINT)
+        except Exception:
+            pass
+        proc.kill()
+        raise
+    return out, err
+
+
+def invoke_codex(
+    *,
+    codex_bin: str,
+    prompt: str,
+    work_dir: str,
+    output_path: str,
+    timeout: float = 60.0,
+    extra_flags: Sequence[str] | None = None,
+):
+    """Run codex in exec mode and return the last assistant message.
+
+    ``codex`` will write its final assistant message to ``output_path`` which
+    is then read, stripped of optional Markdown fences, and returned as a
+    string.  If the message parses as JSON, the parsed object is returned,
+    otherwise the raw string is wrapped in ``{"raw": ...}``.
+    """
+
+    cmd = [
+        codex_bin,
+        "exec",
+        "--output-last-message",
+        output_path,
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+        "-C",
+        work_dir,
+        *(extra_flags or []),
+    ]
+
+    _invoke_codex(cmd, prompt, timeout)
+
+    last = Path(output_path).read_text(encoding="utf-8").strip()
+    if last.startswith("```"):
+        lines = last.splitlines()[1:]
+        if lines and lines[-1].startswith("```"):
+            lines = lines[:-1]
+        last = "\n".join(lines)
+    try:
+        return json.loads(last)
+    except json.JSONDecodeError:
+        return {"raw": last}

--- a/tests/test_codex_exec.py
+++ b/tests/test_codex_exec.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+from codex_exec import invoke_codex
+
+
+def _make_codex_stub(tmp_path: Path) -> Path:
+    script = tmp_path / "codex"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, sys, pathlib\n"
+        "out_path = sys.argv[sys.argv.index('--output-last-message') + 1]\n"
+        "prompt = sys.stdin.read().strip()\n"
+        "pathlib.Path(out_path).write_text('```json\\n' + json.dumps({'echo': prompt}) + '\\n```')\n"
+        "print('ok')\n"
+    )
+    script.chmod(0o755)
+    return script
+
+
+def test_invoke_codex_parses_last_message(tmp_path: Path) -> None:
+    codex_bin = _make_codex_stub(tmp_path)
+    output_file = tmp_path / "out.txt"
+    res = invoke_codex(
+        codex_bin=str(codex_bin),
+        prompt="hello",
+        work_dir=str(tmp_path),
+        output_path=str(output_file),
+        timeout=1,
+    )
+    assert res == {"echo": "hello"}
+


### PR DESCRIPTION
## Summary
- add `_invoke_codex` to run codex exec with prompt over stdin
- expose `invoke_codex` for parsing the persisted last message
- cover helper with a stub-based test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689962840650832496b3631af0facf8c