### PR TITLE
Add manifest runner for codex

### DIFF
--- a/codex_manifest_runner.py
+++ b/codex_manifest_runner.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+def _iter_manifest_files(manifest_path: Path) -> Iterable[Path]:
+    """Yield file paths listed in ``manifest_path``.
+
+    The manifest may be a JSON file of the form ``{"files": [...]}`` or a
+    simple newline-delimited text file.  Paths are yielded exactly as they
+    appear in the manifest (no normalization is performed).
+    """
+
+    if manifest_path.suffix == ".json":
+        data = json.loads(manifest_path.read_text())
+        for entry in data.get("files", []):
+            yield Path(entry)
+    else:
+        for line in manifest_path.read_text().splitlines():
+            entry = line.strip()
+            if entry:
+                yield Path(entry)
+
+
+def _invoke_codex(codex_bin: str, file_path: Path, output_dir: Path) -> str:
+    """Invoke codex for ``file_path`` and return the last message."""
+
+    work_dir = file_path.parent
+    digest = hashlib.sha256(str(file_path).encode()).hexdigest()[:8]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{digest}.txt"
+
+    cmd = [
+        codex_bin,
+        "exec",
+        "--output-last-message",
+        str(output_path),
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check",
+        "-C",
+        str(work_dir),
+    ]
+
+    proc = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    proc.wait()
+    return output_path.read_text().strip()
+
+
+def run_manifest(
+    codex_bin: str, manifest_path: Path, output_dir: Path = Path("codex_outputs")
+) -> Dict[Path, str]:
+    """Run codex for each file in ``manifest_path``.
+
+    Returns a mapping from each manifest file path to the final assistant
+    message written by codex.
+    """
+
+    results: Dict[Path, str] = {}
+    for file_path in _iter_manifest_files(manifest_path):
+        results[file_path] = _invoke_codex(codex_bin, file_path, output_dir)
+    return results
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("codex_bin", help="Path to the codex executable")
+    ap.add_argument("manifest", help="Path to manifest.json or manifest.txt")
+    ap.add_argument(
+        "--output-dir",
+        default="codex_outputs",
+        help="Directory where codex last messages will be written",
+    )
+    args = ap.parse_args(argv)
+
+    run_manifest(args.codex_bin, Path(args.manifest), Path(args.output_dir))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/tests/test_codex_manifest_runner.py
+++ b/tests/test_codex_manifest_runner.py
@@ -1,0 +1,45 @@
+import json
+import os
+from pathlib import Path
+import hashlib
+
+from codex_manifest_runner import run_manifest
+
+
+def _make_codex_stub(tmp_path: Path) -> Path:
+    script = tmp_path / "codex"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys, pathlib\n"
+        "out_path = sys.argv[sys.argv.index('--output-last-message') + 1]\n"
+        "work_dir = sys.argv[sys.argv.index('-C') + 1]\n"
+        "pathlib.Path(out_path).write_text(work_dir)\n"
+        "print('ran', work_dir)\n"
+    )
+    script.chmod(0o755)
+    return script
+
+
+def test_run_manifest_invokes_codex(tmp_path: Path) -> None:
+    codex_bin = _make_codex_stub(tmp_path)
+
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "file1.txt").write_text("a1")
+    (tmp_path / "b").mkdir()
+    (tmp_path / "b" / "file2.txt").write_text("b2")
+
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"files": ["a/file1.txt", "b/file2.txt"]}))
+
+    out_dir = tmp_path / "outs"
+    prev = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        run_manifest(str(codex_bin), manifest, out_dir)
+    finally:
+        os.chdir(prev)
+
+    digest1 = hashlib.sha256("a/file1.txt".encode()).hexdigest()[:8]
+    digest2 = hashlib.sha256("b/file2.txt".encode()).hexdigest()[:8]
+    assert (out_dir / f"{digest1}.txt").read_text() == "a"
+    assert (out_dir / f"{digest2}.txt").read_text() == "b"


### PR DESCRIPTION
## Summary
- Add utility to run codex against each file in a manifest with deterministic output paths
- Support both JSON and text manifests and stream codex output
- Test manifest runner using a stub codex executable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899650ebcc08324830559f6524d15da