### PR TITLE
Use exec mode for Codex invocation

### DIFF
--- a/tests/test_codex_dispatch.py
+++ b/tests/test_codex_dispatch.py
@@ -10,6 +10,10 @@ def test_exec_handles_keyboard_interrupt(tmp_path):
     codex.write_text(
         """#!/usr/bin/env python3
 import os, signal, sys, time
+out_path = sys.argv[sys.argv.index('--output-last-message') + 1]
+work = sys.argv[sys.argv.index('-C') + 1]
+os.chdir(work)
+open(out_path, 'w').write('')
 open('pid', 'w').write(str(os.getpid()))
 signal.signal(signal.SIGINT, lambda s, f: sys.exit(130))
 time.sleep(60)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -28,6 +28,9 @@ def clean_env(tmp_path, monkeypatch):
     codex.write_text(
         "#! /usr/bin/env python3\n"
         "import sys, json, re, os\n"
+        "out_path = sys.argv[sys.argv.index('--output-last-message') + 1]\n"
+        "work = sys.argv[sys.argv.index('-C') + 1]\n"
+        "os.chdir(work)\n"
         "sys.path.insert(0, os.getcwd())\n"
         "prompt = sys.stdin.read()\n"
         "m = re.search(r'Path: (.*)', prompt)\n"
@@ -41,7 +44,8 @@ def clean_env(tmp_path, monkeypatch):
         "    out = {\"type\":\"exec\",\"task\":payload,\"result\":run_agent(payload)}\n"
         "else:\n"
         "    out = {\"error\":\"unknown\"}\n"
-        "sys.stdout.write(json.dumps(out))\n"
+        "open(out_path, 'w').write(json.dumps(out))\n"
+        "print('ok')\n"
     )
     codex.chmod(0o755)
     monkeypatch.setenv("PATH", f"{codex_dir}:{os.environ['PATH']}")


### PR DESCRIPTION
## Summary
- Run `codex` via `exec` subcommand and persist last message to a temp file
- Update dispatch and pipeline tests for new `codex exec` flow
- Restore `findings` directory placeholder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689966bfe1508324beb4a957199a3c4f