### PR TITLE
Avoid sending temperature for o-prefixed models

### DIFF
--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import util.openai as openai
+
+
+class DummyClient:
+    def __init__(self):
+        self.params = None
+
+    class _Responses:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def create(self, **params):
+            self.outer.params = params
+            return {}
+
+    @property
+    def responses(self):
+        return self._Responses(self)
+
+
+def test_temperature_removed_for_o_models(monkeypatch):
+    dummy = DummyClient()
+    monkeypatch.setattr(openai, "openai_configure_api", lambda: dummy)
+
+    openai.openai_generate_response(messages=[], model="o1-preview")
+    assert "temperature" not in dummy.params
+
+    openai.openai_generate_response(messages=[], model="gpt-4")
+    assert dummy.params["temperature"] == 0

--- a/util/openai.py
+++ b/util/openai.py
@@ -118,9 +118,10 @@ def openai_generate_response(
         "input": messages,  # Responses accepts free-form input; we pass chat-style for continuity.
         "reasoning": {"effort": reasoning_effort},
         "service_tier": service_tier,
-        "temperature": temperature,
         **extra,
     }
+    if not model.startswith("o"):
+        params["temperature"] = temperature
 
     if tools:
         params["tools"] = tools


### PR DESCRIPTION
## Summary
- Skip `temperature` parameter when calling OpenAI models starting with `o`
- Add regression test for temperature omission logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68996fd0d4dc832492102d9b730d290c