### PR TITLE
Add live reporter to audit CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ LLM call fails after internal retries, the run aborts and reports the error.
    - Persist updated finding artifacts, including condition states and evidence trails, back into `findings/`.
    - Only production-grade objects and files are produced; no extraneous or decorative content is saved.
 
+## Live Mode
+
+To stream high-signal progress during a run, pass `--live` to `run_pipeline.py`
+or set the environment variable `ANCHOR_LIVE=1`. Optional `--live-format=json`
+emits JSON lines instead of text.
+

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from test_pipeline import run_pipeline, clean_env
+
+
+def test_run_pipeline_live(monkeypatch, clean_env):
+    manifest = Path("manifest.txt")
+    manifest.write_text("examples/example1.py")
+    res = run_pipeline(monkeypatch, args=["--live"])
+    assert res.returncode == 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,7 +55,7 @@ def clean_env(tmp_path, monkeypatch):
         shutil.rmtree(findings)
 
 
-def run_pipeline(monkeypatch, llm_stub=None) -> SimpleNamespace:
+def run_pipeline(monkeypatch, llm_stub=None, args=None) -> SimpleNamespace:
     import run_pipeline as rp
 
     if llm_stub is None:
@@ -71,7 +71,7 @@ def run_pipeline(monkeypatch, llm_stub=None) -> SimpleNamespace:
 
     monkeypatch.setattr("orchestrator.openai_generate_response", llm_stub)
     try:
-        rp.main()
+        rp.main(args or [])
         return SimpleNamespace(returncode=0, stdout="", stderr="")
     except SystemExit as exc:
         return SimpleNamespace(returncode=exc.code, stdout="", stderr="")

--- a/util/reporter.py
+++ b/util/reporter.py
@@ -1,0 +1,36 @@
+import json
+import os
+from typing import Any
+
+class Reporter:
+    """Lightweight event reporter for optional live mode."""
+
+    def __init__(self, enabled: bool = False, fmt: str = "text") -> None:
+        self.enabled = enabled
+        self.fmt = fmt
+
+    @classmethod
+    def from_env(
+        cls, *, enabled: bool = False, fmt: str = "text"
+    ) -> "Reporter":
+        env_enabled = os.getenv("ANCHOR_LIVE")
+        if env_enabled and env_enabled not in {"0", "false", "False"}:
+            enabled = True
+        env_fmt = os.getenv("ANCHOR_LIVE_FORMAT")
+        if env_fmt:
+            fmt = env_fmt
+        return cls(enabled=enabled, fmt=fmt)
+
+    def log(self, event: str, **data: Any) -> None:
+        if not self.enabled:
+            return
+        if self.fmt == "json":
+            payload = {"event": event, **data}
+            print(json.dumps(payload), flush=True)
+        else:
+            parts = [event]
+            for k, v in data.items():
+                if isinstance(v, (list, tuple)):
+                    v = ",".join(str(x) for x in v)
+                parts.append(f"{k}={v}")
+            print(" ".join(parts), flush=True)


### PR DESCRIPTION
## Summary
- add Reporter utility and `--live`/`--live-format` flags for optional live output
- stream concise orchestration events (findings, tasks, judge, subconditions) via Reporter
- document live mode and cover with smoke test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689974ee106c832480d8f017a8d526c6