### PR TITLE
Enforce JSON envelopes and verdict aggregation

### DIFF
--- a/codex_exec.py
+++ b/codex_exec.py
@@ -55,12 +55,13 @@ def invoke_codex(
     timeout: float = 60.0,
     extra_flags: Sequence[str] | None = None,
 ):
-    """Run codex in exec mode and return the last assistant message.
+    """Run codex in exec mode and return the parsed last assistant message.
 
-    ``codex`` will write its final assistant message to ``output_path`` which
-    is then read, stripped of optional Markdown fences, and returned as a
-    string.  If the message parses as JSON, the parsed object is returned,
-    otherwise the raw string is wrapped in ``{"raw": ...}``.
+    ``codex`` writes its final assistant message to ``output_path``.  The
+    message is read, stripped of optional Markdown fences, and returned as a
+    parsed JSON object.  If the content cannot be parsed as JSON, a
+    ``json.JSONDecodeError`` is raised to allow callers to fail closed on
+    formatting errors.
     """
 
     cmd = [
@@ -86,4 +87,4 @@ def invoke_codex(
     try:
         return json.loads(last)
     except json.JSONDecodeError:
-        return {"raw": last}
+        raise

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,6 +1,7 @@
 import sys
 import json
 from pathlib import Path
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -68,11 +69,7 @@ def test_discover():
 
 
 def test_exec():
-    data = {
-        "type": "exec",
-        "task": "stat:p",
-        "result": {"type": "stat", "path": "p", "size": 1, "sha1": "aa"},
-    }
+    data = {"type": "exec_observation", "summary": "ok", "citations": []}
     agent = _agent_with_result(data)
     res = agent.run("codex:exec:p::stat:p")
     assert res == data
@@ -152,5 +149,5 @@ def test_invalid_json():
     client = DummyCodexClient(result=result)
     workdir = str(Path(__file__).resolve().parents[1])
     agent = CodexAgent(client, workdir=workdir)
-    res = agent.run("read:examples/example1.py")
-    assert res == "not json"
+    with pytest.raises(ValueError):
+        agent.run("read:examples/example1.py")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -142,5 +142,5 @@ def test_judgement_shortcuts(monkeypatch):
     monkeypatch.setattr(
         "orchestrator.openai_generate_response", lambda *a, **k: fake
     )
-    cond = Condition(description="x", evidence=["e"])
+    cond = Condition(description="x", evidence=[json.dumps({"type": "exec_observation", "summary": "s", "citations": []})])
     assert orch.judge_condition(cond) == "satisfied"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -40,10 +40,7 @@ def clean_env(tmp_path, monkeypatch):
         "if 'Action: DISCOVER' in prompt:\n"
         "    out = {\"type\":\"discover\",\"claim\":f'Review {path}',\"files\":[path],\"evidence\":{}}\n"
         "elif 'Action: EXEC' in prompt:\n"
-        "    tm = re.search(r'Task: (.*)', prompt)\n"
-        "    payload = tm.group(1).strip() if tm else ''\n"
-        "    from agent import run_agent\n"
-        "    out = {\"type\":\"exec\",\"task\":payload,\"result\":run_agent(payload)}\n"
+        "    out = {\"type\":\"exec_observation\",\"summary\":\"ok\",\"citations\":[]}\n"
         "else:\n"
         "    out = {\"error\":\"unknown\"}\n"
         "open(out_path, 'w').write(json.dumps(out))\n"
@@ -172,6 +169,7 @@ def test_seeded_findings_have_claim_and_evidence(monkeypatch):
         assert data["evidence"].get("seed") is not None
         assert "tasks_log" in data
         assert "conditions" in data
+        assert "verdict" in data
 
 
 def test_manifest_is_single_source(monkeypatch):


### PR DESCRIPTION
## Summary
- Require codex exec responses to emit strict `{type, summary, citations, notes}` JSON envelopes and validate them before logging
- Normalize suggested tasks and feed them into planning, using direct read/stat/py calls where obvious
- Judge conditions solely on the latest exec observation and compute a claim-level verdict

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68998bedef6483248278096b8fcff569