### PR TITLE
Refine git change detection and codex execution helpers

### DIFF
--- a/codex_dispatch.py
+++ b/codex_dispatch.py
@@ -74,7 +74,9 @@ class CodexClient:
     ) -> CodexExecResult:
         """Execute codex with the given prompt and return the result."""
 
-        out_file = Path(tempfile.mkstemp(prefix="codex_last_")[1])
+        fd, tmp_path = tempfile.mkstemp(prefix="codex_last_")
+        os.close(fd)
+        out_file = Path(tmp_path)
         cmd = [
             self.bin_path,
             "exec",

--- a/codex_exec.py
+++ b/codex_exec.py
@@ -13,8 +13,10 @@ def invoke_codex(*, codex_bin: str, prompt: str, work_dir: str, output_path: str
         check=True,
     )
     text = Path(output_path).read_text()
-    start = text.find("{")
-    end = text.rfind("}")
-    if start != -1 and end != -1:
-        text = text[start : end + 1]
-    return json.loads(text)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{"); end = text.rfind("}")
+        if start != -1 and end != -1:
+            return json.loads(text[start:end+1])
+        raise

--- a/codex_manifest_runner.py
+++ b/codex_manifest_runner.py
@@ -11,7 +11,7 @@ def run_manifest(codex_bin: str, manifest_path: Path, out_dir: Path) -> None:
         out_file = out_dir / f"{digest}.txt"
         work_dir = Path(file_path).parent
         subprocess.run(
-            [codex_bin, "--output-last-message", str(out_file), "-C", str(work_dir)],
+            [codex_bin, "exec", "--output-last-message", str(out_file), "-C", str(work_dir)],
             input=b"",
             cwd=Path("."),
             check=True,

--- a/util/git_diff.py
+++ b/util/git_diff.py
@@ -9,16 +9,21 @@ from typing import List
 def git_changed_files(since: str | None = None, window_days: int | None = None) -> List[Path]:
     """Return repo-relative Paths changed since ``since`` or within ``window_days``."""
 
-    args = ["git", "diff", "--name-only"]
-    if since:
-        args.append(since)
-    if window_days is not None:
-        since_date = (datetime.utcnow() - timedelta(days=window_days)).strftime("%Y-%m-%d")
-        args.extend(["--since", since_date])
     try:
-        out = subprocess.check_output(args, stderr=subprocess.DEVNULL, text=True)
+        if window_days is not None:
+            since_date = (datetime.utcnow() - timedelta(days=window_days)).strftime("%Y-%m-%d")
+            out = subprocess.check_output(
+                ["git", "log", "--since", since_date, "--name-only", "--pretty=format:"],
+                stderr=subprocess.DEVNULL,
+                text=True,
+            )
+        else:
+            args = ["git", "diff", "--name-only"]
+            if since:
+                args.append(f"{since}..HEAD")
+            out = subprocess.check_output(args, stderr=subprocess.DEVNULL, text=True)
     except Exception:
         return []
     files = [f.strip() for f in out.splitlines() if f.strip()]
-    return [Path(f) for f in files]
+    return [Path(f) for f in files if Path(f).exists() and f.endswith(".py")]
 

--- a/util/imports.py
+++ b/util/imports.py
@@ -95,7 +95,10 @@ def _deps_from_requirements(root: Path) -> set[str]:
     pyproject = root / "pyproject.toml"
     if pyproject.exists():
         try:
-            import tomllib
+            try:
+                import tomllib  # py3.11+
+            except ModuleNotFoundError:
+                import tomli as tomllib  # py3.10
 
             data = tomllib.loads(pyproject.read_text())
             for dep in data.get("project", {}).get("dependencies", []) or []:

--- a/util/live_text.py
+++ b/util/live_text.py
@@ -71,6 +71,7 @@ class LiveTextFormatter:
             self._print_line(0, line)
 
     def _truncate(self, text: str, limit: int) -> str:
+        limit = max(limit, 4)
         if len(text) <= limit:
             return text
         half = max(0, (limit - 3) // 2)
@@ -98,10 +99,7 @@ class LiveTextFormatter:
         text = (
             f"{prefix}Finding {self.idx['finding']}/{self.idx['finding_total']}  {path}  \"{claim}\"{extra}"
         )
-        if self.is_tty:
-            self._print_line(0, text)
-        else:
-            self._print_line(0, text)
+        self._print_line(0, text)
 
     def _on_condition_request(self, claim: str) -> None:
         self.ctx["current_condition"] = claim

--- a/util/openai.py
+++ b/util/openai.py
@@ -200,4 +200,4 @@ def openai_parse_function_call(response: Any) -> Tuple[Optional[str], Any]:
             except Exception:
                 args = {}
             return name, args
-    return None, None
+    return None, {}


### PR DESCRIPTION
## Summary
- Update git change helper to use `git log` for windowed history and filter to existing Python files
- Ensure codex tooling handles exec mode and temporary files cleanly
- Improve robustness of imports, OpenAI parsing, live text formatting, and pipeline compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899c544c42083249a5d1f1d22a884f0