### PR TITLE
Fix LiveTextFormatter tasks_plan signature

### DIFF
--- a/util/live_text.py
+++ b/util/live_text.py
@@ -131,7 +131,7 @@ class LiveTextFormatter:
             self._print_line(base, text)
             self.in_tasks = True
 
-    def _on_tasks_plan(self, tasks: List[str]) -> None:
+    def _on_tasks_plan(self, tasks: List[str], verbs: List[str] | None = None) -> None:
         base = 5 if self.is_tty else 4
         joined = ", ".join(tasks)
         self._print_line(base, f"• plan: {self._truncate(joined, self.width - base - 10)}")


### PR DESCRIPTION
## Summary
- allow `LiveTextFormatter._on_tasks_plan` to accept an optional `verbs` argument
- prevents TypeError when reporters log `tasks:plan` with verbs

## Testing
- `pytest tests/test_live.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899cd7fed9c8324b492847604afd41b