### PR TITLE
Ensure unique finding IDs and add regression test

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -215,7 +215,8 @@ def main(argv: list[str] | None = None) -> None:
             seed_src = f.get("seed_source", "manual")
             abs_path = repo_root / rel_path
             file_bytes = abs_path.read_bytes()
-            finding_id = hashlib.sha1(rel_path.as_posix().encode()).hexdigest()[:12]
+            raw_id = f"{rel_path.as_posix()}|{f['claim']}|{seed_src}"
+            finding_id = hashlib.sha1(raw_id.encode()).hexdigest()[:12]
             finding = {
                 "finding_id": finding_id,
                 "schema_version": 1,
@@ -230,6 +231,8 @@ def main(argv: list[str] | None = None) -> None:
                     "input_hash": hashlib.sha1(file_bytes).hexdigest(),
                     "file_size": len(file_bytes),
                     "path": rel_path.as_posix(),
+                    "claim": f["claim"],
+                    "seed_source": seed_src,
                 },
                 "status": "seeded",
                 "conditions": [],


### PR DESCRIPTION
## Summary
- Generate finding IDs using file path, claim text, and seed source to avoid collisions
- Record claim and seed source in provenance metadata
- Add regression test to verify findings from the same file maintain distinct IDs and adjust pipeline tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899dd6842f8832499739154ec71f430